### PR TITLE
Create the target folder for bundle.js to live in if not already in e…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "standard": "^11.0.1"
   },
   "scripts": {
-    "bundle": "browserify js/src/main/main.js -o js/src/target/bundle.js",
+    "bundle": "mkdir -p js/src/target/ && browserify js/src/main/main.js -o js/src/target/bundle.js",
     "prebundle": "eslint .",
-    "bundleNoLint": "browserify js/src/main/main.js -o js/src/target/bundle.js",
+    "bundleNoLint": "mkdir -p js/src/target/ && browserify js/src/main/main.js -o js/src/target/bundle.js",
     "test": "jest"
   },
   "jest": {


### PR DESCRIPTION
Hey, I hope you don't mind a PR. Just a little change to have the bundle commands create the js/src/target/ folder if it doesn't exist. This solves the issue of Browserify not being able to find the target folder when the repo is freshly cloned.